### PR TITLE
Handle `/peripheral` endpoint error when bad handscanner connected

### DIFF
--- a/src/main/java/com/target/devicemanager/common/DeviceAvailabilityService.java
+++ b/src/main/java/com/target/devicemanager/common/DeviceAvailabilityService.java
@@ -111,14 +111,14 @@ public class DeviceAvailabilityService {
         switch (devName){
             case "flatbedscanner":
                 if(deviceAvailabilitySingleton.getScannerManager() != null) {
-                    healthStatus = getScannerHealthStatus(deviceAvailabilitySingleton, "FLATBED");
+                    healthStatus = deviceAvailabilitySingleton.getScannerManager().getScannerHealthStatus("FLATBED");
                 } else {
                     LOGGER.trace("Failed to Connect to " + devName);
                 }
                 break;
             case "handscanner":
                 if(deviceAvailabilitySingleton.getScannerManager() != null) {
-                    healthStatus = getScannerHealthStatus(deviceAvailabilitySingleton, "HANDHELD");
+                    healthStatus = deviceAvailabilitySingleton.getScannerManager().getScannerHealthStatus("HANDHELD");
                 } else {
                     LOGGER.trace("Failed to Connect to " + devName);
                 }
@@ -148,15 +148,6 @@ public class DeviceAvailabilityService {
                 LOGGER.trace("Not a known device. " + devName);
         }
         return healthStatus;
-    }
-
-    public DeviceHealth getScannerHealthStatus(DeviceAvailabilitySingleton deviceAvailabilitySingleton, String scannerName) {
-        for(DeviceHealthResponse deviceHealthResponse: deviceAvailabilitySingleton.getScannerManager().getStatus()) {
-            if(deviceHealthResponse.getDeviceName().equals(scannerName)) {
-                return deviceHealthResponse.getHealthStatus();
-            }
-        }
-        return new DeviceHealthResponse(scannerName, DeviceHealth.NOTREADY).getHealthStatus();
     }
 
     public void subscribeToDeviceError(SseEmitter sseEmitter) throws IOException {

--- a/src/main/java/com/target/devicemanager/common/DeviceAvailabilityService.java
+++ b/src/main/java/com/target/devicemanager/common/DeviceAvailabilityService.java
@@ -111,14 +111,14 @@ public class DeviceAvailabilityService {
         switch (devName){
             case "flatbedscanner":
                 if(deviceAvailabilitySingleton.getScannerManager() != null) {
-                    healthStatus = deviceAvailabilitySingleton.getScannerManager().getStatus().get(0).getHealthStatus();
+                    healthStatus = getScannerHealthStatus(deviceAvailabilitySingleton, "FLATBED");
                 } else {
                     LOGGER.trace("Failed to Connect to " + devName);
                 }
                 break;
             case "handscanner":
                 if(deviceAvailabilitySingleton.getScannerManager() != null) {
-                    healthStatus = deviceAvailabilitySingleton.getScannerManager().getStatus().get(1).getHealthStatus();
+                    healthStatus = getScannerHealthStatus(deviceAvailabilitySingleton, "HANDHELD");
                 } else {
                     LOGGER.trace("Failed to Connect to " + devName);
                 }
@@ -150,6 +150,14 @@ public class DeviceAvailabilityService {
         return healthStatus;
     }
 
+    public DeviceHealth getScannerHealthStatus(DeviceAvailabilitySingleton deviceAvailabilitySingleton, String scannerName) {
+        for(DeviceHealthResponse deviceHealthResponse: deviceAvailabilitySingleton.getScannerManager().getStatus()) {
+            if(deviceHealthResponse.getDeviceName().equals(scannerName)) {
+                return deviceHealthResponse.getHealthStatus();
+            }
+        }
+        return new DeviceHealthResponse(scannerName, DeviceHealth.NOTREADY).getHealthStatus();
+    }
 
     public void subscribeToDeviceError(SseEmitter sseEmitter) throws IOException {
         sseEmitter.onCompletion(() -> this.deviceErrorClientList.remove(sseEmitter));

--- a/src/main/java/com/target/devicemanager/components/scanner/ScannerManager.java
+++ b/src/main/java/com/target/devicemanager/components/scanner/ScannerManager.java
@@ -1,6 +1,5 @@
 package com.target.devicemanager.components.scanner;
 
-import com.target.devicemanager.common.DeviceAvailabilitySingleton;
 import com.target.devicemanager.common.entities.*;
 import com.target.devicemanager.components.scanner.entities.Barcode;
 import com.target.devicemanager.components.scanner.entities.ScannerError;

--- a/src/main/java/com/target/devicemanager/components/scanner/ScannerManager.java
+++ b/src/main/java/com/target/devicemanager/components/scanner/ScannerManager.java
@@ -1,5 +1,6 @@
 package com.target.devicemanager.components.scanner;
 
+import com.target.devicemanager.common.DeviceAvailabilitySingleton;
 import com.target.devicemanager.common.entities.*;
 import com.target.devicemanager.components.scanner.entities.Barcode;
 import com.target.devicemanager.components.scanner.entities.ScannerError;
@@ -212,6 +213,15 @@ public class ScannerManager {
             LOGGER.debug("Not able to retrieve from cache, checking getHealth()");
             return getHealth(ScannerType.BOTH);
         }
+    }
+
+    public DeviceHealth getScannerHealthStatus(String scannerName) {
+        for(DeviceHealthResponse deviceHealthResponse: getStatus()) {
+            if(deviceHealthResponse.getDeviceName().equals(scannerName)) {
+                return deviceHealthResponse.getHealthStatus();
+            }
+        }
+        return new DeviceHealthResponse(scannerName, DeviceHealth.NOTREADY).getHealthStatus();
     }
 
     private void disableScanners() throws InterruptedException {

--- a/src/test/java/com/target/devicemanager/common/DeviceAvailabilityServiceTest.java
+++ b/src/test/java/com/target/devicemanager/common/DeviceAvailabilityServiceTest.java
@@ -74,47 +74,29 @@ class DeviceAvailabilityServiceTest {
     @Test
     void Test_findDevStatus_FlatbedScanner() {
         //arrange
-        List<DeviceHealthResponse> devReady = new ArrayList<>();
-        devReady.add(new DeviceHealthResponse("FLATBED", DeviceHealth.READY));
-        devReady.add(new DeviceHealthResponse("HANDHELD", DeviceHealth.READY));
+        DeviceHealth expected = new DeviceHealthResponse("FLATBED", DeviceHealth.NOTREADY).getHealthStatus();
         deviceAvailabilitySingleton.setScannerManager(mockScannerManager);
-        when(deviceAvailabilitySingleton.getScannerManager().getStatus()).thenReturn(devReady);
+        when(deviceAvailabilitySingleton.getScannerManager().getScannerHealthStatus("FLATBED")).thenReturn(expected);
 
         //act
         DeviceHealth actual = deviceAvailabilityService.findDevStatus("flatbedscanner");
+
         //assert
-        assertEquals(DeviceHealth.READY, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     void Test_findDevStatus_HandScanner() {
         //arrange
-        List<DeviceHealthResponse> devReady = new ArrayList<>();
-        devReady.add(new DeviceHealthResponse("FLATBED", DeviceHealth.READY));
-        devReady.add(new DeviceHealthResponse("HANDHELD", DeviceHealth.READY));
+        DeviceHealth expected = new DeviceHealthResponse("HANDHELD", DeviceHealth.READY).getHealthStatus();
         deviceAvailabilitySingleton.setScannerManager(mockScannerManager);
-        when(deviceAvailabilitySingleton.getScannerManager().getStatus()).thenReturn(devReady);
-
+        when(deviceAvailabilitySingleton.getScannerManager().getScannerHealthStatus("HANDHELD")).thenReturn(expected);
 
         //act
         DeviceHealth actual = deviceAvailabilityService.findDevStatus("handscanner");
 
         //assert
-        assertEquals(DeviceHealth.READY, actual);
-    }
-
-    @Test
-    void Test_findDevStatus_HandheldScanner_missing() {
-        //arrange
-        List<DeviceHealthResponse> devReady = new ArrayList<>();
-        devReady.add(new DeviceHealthResponse("FLATBED", DeviceHealth.READY));
-        deviceAvailabilitySingleton.setScannerManager(mockScannerManager);
-        when(deviceAvailabilitySingleton.getScannerManager().getStatus()).thenReturn(devReady);
-
-        //act
-        DeviceHealth actual = deviceAvailabilityService.findDevStatus("handscanner");
-        //assert
-        assertEquals(DeviceHealth.NOTREADY, actual);
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/com/target/devicemanager/common/DeviceAvailabilityServiceTest.java
+++ b/src/test/java/com/target/devicemanager/common/DeviceAvailabilityServiceTest.java
@@ -75,30 +75,46 @@ class DeviceAvailabilityServiceTest {
     void Test_findDevStatus_FlatbedScanner() {
         //arrange
         List<DeviceHealthResponse> devReady = new ArrayList<>();
-        devReady.add(new DeviceHealthResponse("Flatbed", DeviceHealth.READY));
-        devReady.add(new DeviceHealthResponse("HandScanner", DeviceHealth.READY));
+        devReady.add(new DeviceHealthResponse("FLATBED", DeviceHealth.READY));
+        devReady.add(new DeviceHealthResponse("HANDHELD", DeviceHealth.READY));
+        deviceAvailabilitySingleton.setScannerManager(mockScannerManager);
+        when(deviceAvailabilitySingleton.getScannerManager().getStatus()).thenReturn(devReady);
 
         //act
-        deviceAvailabilitySingleton.setScannerManager(mockScannerManager);
-
+        DeviceHealth actual = deviceAvailabilityService.findDevStatus("flatbedscanner");
         //assert
-        when(deviceAvailabilitySingleton.getScannerManager().getStatus()).thenReturn(devReady);
-        assertEquals(DeviceHealth.READY, deviceAvailabilityService.findDevStatus("flatbedscanner"));
+        assertEquals(DeviceHealth.READY, actual);
     }
 
     @Test
     void Test_findDevStatus_HandScanner() {
         //arrange
         List<DeviceHealthResponse> devReady = new ArrayList<>();
-        devReady.add(new DeviceHealthResponse("Flatbed", DeviceHealth.READY));
-        devReady.add(new DeviceHealthResponse("HandScanner", DeviceHealth.READY));
+        devReady.add(new DeviceHealthResponse("FLATBED", DeviceHealth.READY));
+        devReady.add(new DeviceHealthResponse("HANDHELD", DeviceHealth.READY));
+        deviceAvailabilitySingleton.setScannerManager(mockScannerManager);
+        when(deviceAvailabilitySingleton.getScannerManager().getStatus()).thenReturn(devReady);
+
 
         //act
-        deviceAvailabilitySingleton.setScannerManager(mockScannerManager);
+        DeviceHealth actual = deviceAvailabilityService.findDevStatus("handscanner");
 
         //assert
+        assertEquals(DeviceHealth.READY, actual);
+    }
+
+    @Test
+    void Test_findDevStatus_HandheldScanner_missing() {
+        //arrange
+        List<DeviceHealthResponse> devReady = new ArrayList<>();
+        devReady.add(new DeviceHealthResponse("FLATBED", DeviceHealth.READY));
+        deviceAvailabilitySingleton.setScannerManager(mockScannerManager);
         when(deviceAvailabilitySingleton.getScannerManager().getStatus()).thenReturn(devReady);
-        assertEquals(DeviceHealth.READY, deviceAvailabilityService.findDevStatus("handscanner"));
+
+        //act
+        DeviceHealth actual = deviceAvailabilityService.findDevStatus("handscanner");
+        //assert
+        assertEquals(DeviceHealth.NOTREADY, actual);
     }
 
     @Test

--- a/src/test/java/com/target/devicemanager/components/scanner/ScannerManagerTest.java
+++ b/src/test/java/com/target/devicemanager/components/scanner/ScannerManagerTest.java
@@ -1,5 +1,6 @@
 package com.target.devicemanager.components.scanner;
 
+import com.target.devicemanager.common.DeviceAvailabilitySingleton;
 import com.target.devicemanager.common.entities.DeviceError;
 import com.target.devicemanager.common.entities.DeviceException;
 import com.target.devicemanager.common.entities.DeviceHealth;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -108,7 +110,7 @@ public class ScannerManagerTest {
         reconnectResults = new ArrayList<>();
         reconnectResults.add(mockFuture);
         scannerManager = new ScannerManager(scannerDevices, mockScannerLock);
-        scannerManagerCache = new ScannerManager(scannerDevices, mockScannerLock, mockCacheManager, mockExecutor, reconnectResults, true);
+        scannerManagerCache = Mockito.spy(new ScannerManager(scannerDevices, mockScannerLock, mockCacheManager, mockExecutor, reconnectResults, true));
     }
 
     @Test
@@ -554,5 +556,49 @@ public class ScannerManagerTest {
 
         //assert
         assertEquals(expectedList.toString(), deviceHealthResponseList.toString());
+    }
+
+    @Test
+    void getScannerHealthStatus_FlatbedScanner() {
+        //arrange
+        List<DeviceHealthResponse> devReady = new ArrayList<>();
+        devReady.add(new DeviceHealthResponse("FLATBED", DeviceHealth.READY));
+        devReady.add(new DeviceHealthResponse("HANDHELD", DeviceHealth.READY));
+        Mockito.doReturn(devReady).when(scannerManagerCache).getStatus();
+
+        //act
+        DeviceHealth actual = scannerManagerCache.getScannerHealthStatus("HANDHELD");
+
+        //assert
+        assertEquals(DeviceHealth.READY, actual);
+    }
+
+    @Test
+    void getScannerHealthStatus_HandScanner() {
+        //arrange
+        List<DeviceHealthResponse> devReady = new ArrayList<>();
+        devReady.add(new DeviceHealthResponse("FLATBED", DeviceHealth.READY));
+        devReady.add(new DeviceHealthResponse("HANDHELD", DeviceHealth.READY));
+        Mockito.doReturn(devReady).when(scannerManagerCache).getStatus();
+
+        //act
+        DeviceHealth actual = scannerManagerCache.getScannerHealthStatus("HANDHELD");
+
+        //assert
+        assertEquals(DeviceHealth.READY, actual);
+    }
+
+    @Test
+    void getScannerHealthStatus_HandheldScanner_missing() {
+        //arrange
+        List<DeviceHealthResponse> devReady = new ArrayList<>();
+        devReady.add(new DeviceHealthResponse("FLATBED", DeviceHealth.READY));
+        Mockito.doReturn(devReady).when(scannerManagerCache).getStatus();
+
+        //act
+        DeviceHealth actual = scannerManagerCache.getScannerHealthStatus("HANDHELD");
+
+        //assert
+        assertEquals(DeviceHealth.NOTREADY, actual);
     }
 }

--- a/src/test/java/com/target/devicemanager/components/scanner/ScannerManagerTest.java
+++ b/src/test/java/com/target/devicemanager/components/scanner/ScannerManagerTest.java
@@ -1,6 +1,5 @@
 package com.target.devicemanager.components.scanner;
 
-import com.target.devicemanager.common.DeviceAvailabilitySingleton;
 import com.target.devicemanager.common.entities.DeviceError;
 import com.target.devicemanager.common.entities.DeviceException;
 import com.target.devicemanager.common.entities.DeviceHealth;


### PR DESCRIPTION
Description of changes:
- Removed logic that assumes that both scanners will be connected at startup

Description of testing: 
- Tested in the lab to verify that when the hand scanner is disconnected it does not break the peripherals endpoint
- Tested in the lab to verify that when the flatbed scanner is disconnected it does not break the peripherals endpoint
- Tested in the lab to verify that when both scanners are disconnected it does not break the peripherals endpoint


Please make sure the following changes have been made before creating a pull request.

Update `Description`
- [x] `Change tested on actual device`
- [ ] `Changes tested for simulator`
- [x] `Existing device functionality is working fine`
- [x] `Unit Tests Written for Code Changes, and Verified that Coverage is 100% for Modified Files(with the exception of ATM devices)`
