### PR TITLE
Fix printer lock stuck

### DIFF
--- a/src/main/java/com/target/devicemanager/components/printer/PrinterDevice.java
+++ b/src/main/java/com/target/devicemanager/components/printer/PrinterDevice.java
@@ -165,14 +165,14 @@ public class PrinterDevice implements StatusUpdateListener{
     public Void printContent(List<PrinterContent> contents, int printerStation) throws JposException, PrinterException {
         LOGGER.debug("printContent()");
         if(tryLock()) {
-            if (contents == null || contents.isEmpty()) {
-                LOGGER.debug("Receipt contents are empty");
-                return null;
-            }
-            enable();
             POSPrinter printer;
             synchronized (printer = dynamicPrinter.getDevice()) {
                 try {
+                    if (contents == null || contents.isEmpty()) {
+                        LOGGER.debug("Receipt contents are empty");
+                        throw new PrinterException(PrinterError.INVALID_FORMAT);
+                    }
+                    enable();
                     if (printerStation != PrinterStationType.CHECK_PRINTER.getValue() && (wasPaperEmpty || paperEmptyCheck())) {
                         // Throw JPOS extended error JPOS_EPTR_REC_EMPTY
                         throw new JposException(114, 203);

--- a/src/test/java/com/target/devicemanager/components/printer/PrinterDeviceTest.java
+++ b/src/test/java/com/target/devicemanager/components/printer/PrinterDeviceTest.java
@@ -357,12 +357,18 @@ public class PrinterDeviceTest {
         //arrange
 
         //act
-        printerDevice.printContent(null, 0);
-
+        try {
+            printerDevice.printContent(null, 0);
+        }
         //assert
-        verify(mockDynamicPrinter, never()).getDevice();
-        verify(mockPrinter, never()).transactionPrint(anyInt(), anyInt());
-        verify(mockPrinter, never()).clearOutput();
+        catch (PrinterException printerException) {
+            verify(mockDynamicPrinter, times(1)).getDevice();
+            verify(mockPrinter, never()).transactionPrint(anyInt(), anyInt());
+            verify(mockPrinter, times(1)).clearOutput();
+            return;
+        } catch (JposException jposException) {
+            fail("Expected PrinterException, got JposException");
+        }
     }
 
     @Test
@@ -371,12 +377,18 @@ public class PrinterDeviceTest {
         List<PrinterContent> contents = new ArrayList<>();
 
         //act
-        printerDevice.printContent(contents, 0);
-
+        try {
+            printerDevice.printContent(contents, 0);
+        }
         //assert
-        verify(mockDynamicPrinter, never()).getDevice();
-        verify(mockPrinter, never()).transactionPrint(anyInt(), anyInt());
-        verify(mockPrinter, never()).clearOutput();
+        catch (PrinterException printerException) {
+            verify(mockDynamicPrinter, times(1)).getDevice();
+            verify(mockPrinter, never()).transactionPrint(anyInt(), anyInt());
+            verify(mockPrinter, times(1)).clearOutput();
+            return;
+        } catch (JposException jposException) {
+            fail("Expected PrinterException, got JposException");
+        }
     }
 
     @Test
@@ -399,9 +411,9 @@ public class PrinterDeviceTest {
 
         //assert
         catch (JposException jposException) {
-            verify(mockDynamicPrinter, never()).getDevice();
+            verify(mockDynamicPrinter, times(1)).getDevice();
             verify(mockPrinter, never()).transactionPrint(anyInt(), anyInt());
-            verify(mockPrinter, never()).clearOutput();
+            verify(mockPrinter, times(1)).clearOutput();
             return;
         } catch (PrinterException printerException) {
             fail("Expected JposException, got PrinterException");


### PR DESCRIPTION
Description of changes:
- Fix lock getting stuck on if printer enable fails

Description of testing:
- Unit tests verify that unlock occurs if enable throws exception
- Put printer into bad state and attempt multiple prints, verify that printer isn't already locked

Please make sure the following changes have been made before creating a pull request.

Update `Description`
- [ ] `Change tested on actual device`
- [ ] `Changes tested for simulator`
- [ ] `Existing device functionality is working fine`
- [ ] `Unit Tests Written for Code Changes, and Verified that Coverage is 100% for Modified Files(with the exception of ATM devices)`
