### PR TITLE
PNA-2041: Withdraw check if MICR insertion fails

### DIFF
--- a/src/main/java/com/target/devicemanager/components/check/MicrController.java
+++ b/src/main/java/com/target/devicemanager/components/check/MicrController.java
@@ -70,7 +70,7 @@ public class MicrController {
                     content = @Content(schema = @Schema(implementation = DeviceError.class)))
     })
     public void print(@Parameter(description = "Check Print Data") @Valid @RequestBody List<PrinterContent> contents) throws PrinterException {
-        String url = "/v1/check";
+        String url = "POST /v1/check";
         LOGGER.info("request: " + url);
         if(contents.size() < PRINT_CONTENT_SIZE){
             try {
@@ -97,7 +97,7 @@ public class MicrController {
                     content = @Content(schema = @Schema(implementation = MicrError.class)))
     })
     public MicrData readCheck() throws MicrException {
-        String url = "/v1/check";
+        String url = "GET /v1/check";
         LOGGER.info("request: " + url);
         CompletableFuture<MicrData> micrDataClient = new CompletableFuture<>();
         try {

--- a/src/main/java/com/target/devicemanager/components/check/MicrDevice.java
+++ b/src/main/java/com/target/devicemanager/components/check/MicrDevice.java
@@ -189,6 +189,13 @@ public class MicrDevice implements StatusUpdateListener, ErrorListener, DataList
                         this.micrEventListeners.forEach(listener -> listener
                                 .micrErrorEventOccurred(new MicrErrorEvent(this, jposException)));
                         setCheckCancelReceived(true);
+                        try {
+                            // Insert may fail if a check is already inserted from a previous MICR read,
+                            // calling withdraw to return the printer to a state that is ready for the next MICR read
+                            withdrawCheck();
+                        } catch (JposException jposException1) {
+                            // withdrawCheck() logs exceptions within the method, throwing original insertion exception
+                        }
                         throw new MicrException(jposException);
                     }
                 }

--- a/src/test/java/com/target/devicemanager/components/check/MicrDeviceTest.java
+++ b/src/test/java/com/target/devicemanager/components/check/MicrDeviceTest.java
@@ -1,6 +1,7 @@
 package com.target.devicemanager.components.check;
 
 import com.target.devicemanager.common.DynamicDevice;
+import com.target.devicemanager.common.entities.DeviceError;
 import com.target.devicemanager.common.entities.DeviceException;
 import com.target.devicemanager.common.events.ConnectionEvent;
 import com.target.devicemanager.common.events.ConnectionEventListener;
@@ -586,6 +587,24 @@ public class MicrDeviceTest {
 
         //assert
         verify(mockMicr).endInsertion();
+    }
+
+    @Test
+    public void insertCheck_InsertionExceptionAndWithdrawException() throws JposException {
+        //arrange
+        doThrow(new JposException(JposConst.JPOS_E_FAILURE)).when(mockMicr).endInsertion();
+        doThrow(new JposException(MICRConst.JPOS_EMICR_COVEROPEN)).when(mockMicr).endRemoval();
+
+        //act
+        try {
+            micrDevice.insertCheck();
+        } catch (MicrException micrException) {
+            assertEquals(micrException.getDeviceError(), DeviceError.UNEXPECTED_ERROR);
+            return;
+        }
+
+        //assert
+        fail("Expected exception, but got none");
     }
 
     @Test


### PR DESCRIPTION
Description of changes:
- MICR insertion may throw an error if a check is already inserted from a previous MICR read, withdraw the check if an error is received to return the MICR to a state where it is ready to read checks.

Description of testing:

Please make sure the following changes have been made before creating a pull request.

Update `Description`
- [x] `Change tested on actual device`
- [ ] `Changes tested for simulator`
- [x] `Existing device functionality is working fine`
- [x] `Unit Tests Written for Code Changes, and Verified that Coverage is 100% for Modified Files(with the exception of ATM devices)`
