### PR TITLE
Remove Excess Logging for Disconnected Scanners

### DIFF
--- a/src/main/java/com/target/devicemanager/components/scanner/ScannerDevice.java
+++ b/src/main/java/com/target/devicemanager/components/scanner/ScannerDevice.java
@@ -217,7 +217,7 @@ public class ScannerDevice {
         LOGGER.trace(getScannerType() + "enable(in)");
         if (!isConnected()) {
             JposException jposException = new JposException(JposConst.JPOS_E_OFFLINE);
-            LOGGER.error(getScannerType() + " Failed to Connect Device: " + jposException.getErrorCode() + ", " + jposException.getErrorCodeExtended());
+            //LOGGER.error(getScannerType() + " Failed to Connect Device: " + jposException.getErrorCode() + ", " + jposException.getErrorCodeExtended());
             throw jposException;
         }
         deviceListener.startEventListeners();
@@ -268,7 +268,7 @@ public class ScannerDevice {
         } catch (JposException jposException) {
             if(isConnected()) {
                 LOGGER.error(MARKER, getScannerType() + " Failed to Disable Device: " + jposException.getErrorCode() + ", " + jposException.getErrorCodeExtended());
-            } else {
+            } else if(jposException.getErrorCode() != JposConst.JPOS_E_CLOSED) {
                 LOGGER.error(getScannerType() + " Failed to Disable Device: " + jposException.getErrorCode() + ", " + jposException.getErrorCodeExtended());
             }
             if(getScannerType().equalsIgnoreCase("HANDHELD")) {

--- a/src/main/java/com/target/devicemanager/components/scanner/ScannerDevice.java
+++ b/src/main/java/com/target/devicemanager/components/scanner/ScannerDevice.java
@@ -217,7 +217,6 @@ public class ScannerDevice {
         LOGGER.trace(getScannerType() + "enable(in)");
         if (!isConnected()) {
             JposException jposException = new JposException(JposConst.JPOS_E_OFFLINE);
-            //LOGGER.error(getScannerType() + " Failed to Connect Device: " + jposException.getErrorCode() + ", " + jposException.getErrorCodeExtended());
             throw jposException;
         }
         deviceListener.startEventListeners();

--- a/src/main/java/com/target/devicemanager/components/scanner/ScannerManager.java
+++ b/src/main/java/com/target/devicemanager/components/scanner/ScannerManager.java
@@ -63,6 +63,11 @@ public class ScannerManager {
         scanners.forEach(ScannerDevice::connect);
 
         if (connectStatus == ConnectEnum.FIRST_CONNECT) {
+            for (ScannerDevice scanner : scanners) {
+                if(!scanner.isConnected()) {
+                    LOGGER.error(scanner.getScannerType() + " Failed to Connect");
+                }
+            }
             connectStatus = ConnectEnum.CHECK_HEALTH;
         }
     }


### PR DESCRIPTION
Description of changes:
- Remove Excess Logging for Disconnected Scanners

Description of testing:
Tested to ensure logging was limited when handscanner and/or flatbed scanner was disconnected on startup

Please make sure the following changes have been made before creating a pull request.

Update `Description`
- [x] `Change tested on actual device`
- [x] `Changes tested for simulator`
- [x] `Existing device functionality is working fine`
- [na] `Unit Tests Written for Code Changes, and Verified that Coverage is 100% for Modified Files(with the exception of ATM devices)`
