### PR TITLE
Check for Scanner Name in Peripherals Endpoint

### DIFF
--- a/src/main/java/com/target/devicemanager/common/DeviceAvailabilityService.java
+++ b/src/main/java/com/target/devicemanager/common/DeviceAvailabilityService.java
@@ -111,14 +111,16 @@ public class DeviceAvailabilityService {
         switch (devName){
             case "flatbedscanner":
                 if(deviceAvailabilitySingleton.getScannerManager() != null) {
-                    healthStatus = deviceAvailabilitySingleton.getScannerManager().getStatus().get(0).getHealthStatus();
+                    healthStatus = deviceAvailabilitySingleton.getScannerManager().getScannerHealthStatus("FLATBED");
+                    //healthStatus = deviceAvailabilitySingleton.getScannerManager().getStatus().get(0).getHealthStatus();
                 } else {
                     LOGGER.trace("Failed to Connect to " + devName);
                 }
                 break;
             case "handscanner":
                 if(deviceAvailabilitySingleton.getScannerManager() != null) {
-                    healthStatus = deviceAvailabilitySingleton.getScannerManager().getStatus().get(1).getHealthStatus();
+                    healthStatus = deviceAvailabilitySingleton.getScannerManager().getScannerHealthStatus("HANDHELD");
+                    //healthStatus = deviceAvailabilitySingleton.getScannerManager().getStatus().get(1).getHealthStatus();
                 } else {
                     LOGGER.trace("Failed to Connect to " + devName);
                 }

--- a/src/main/java/com/target/devicemanager/common/DeviceAvailabilityService.java
+++ b/src/main/java/com/target/devicemanager/common/DeviceAvailabilityService.java
@@ -112,7 +112,6 @@ public class DeviceAvailabilityService {
             case "flatbedscanner":
                 if(deviceAvailabilitySingleton.getScannerManager() != null) {
                     healthStatus = deviceAvailabilitySingleton.getScannerManager().getScannerHealthStatus("FLATBED");
-                    //healthStatus = deviceAvailabilitySingleton.getScannerManager().getStatus().get(0).getHealthStatus();
                 } else {
                     LOGGER.trace("Failed to Connect to " + devName);
                 }
@@ -120,7 +119,6 @@ public class DeviceAvailabilityService {
             case "handscanner":
                 if(deviceAvailabilitySingleton.getScannerManager() != null) {
                     healthStatus = deviceAvailabilitySingleton.getScannerManager().getScannerHealthStatus("HANDHELD");
-                    //healthStatus = deviceAvailabilitySingleton.getScannerManager().getStatus().get(1).getHealthStatus();
                 } else {
                     LOGGER.trace("Failed to Connect to " + devName);
                 }

--- a/src/main/java/com/target/devicemanager/components/scanner/ScannerManager.java
+++ b/src/main/java/com/target/devicemanager/components/scanner/ScannerManager.java
@@ -227,7 +227,20 @@ public class ScannerManager {
         }
     }
 
-    public DeviceHealth getScannerHealthStatus(String scannerName) {
+    public DeviceHealth getScannerHealthStatus(String scannerType) {
+        String scannerName = "";
+        for (ScannerDevice scanner : scanners) {
+            switch (scannerType) {
+                case "FLATBED":
+                case "HANDHELD":
+                    if (scanner.getScannerType().equals(scannerType)) {
+                        scannerName = scanner.getDeviceName();
+                    }
+                    break;
+                default:
+                   scannerName = "";
+            }
+        }
         for(DeviceHealthResponse deviceHealthResponse: getStatus()) {
             if(deviceHealthResponse.getDeviceName().equals(scannerName)) {
                 return deviceHealthResponse.getHealthStatus();

--- a/src/test/java/com/target/devicemanager/common/DeviceAvailabilityServiceTest.java
+++ b/src/test/java/com/target/devicemanager/common/DeviceAvailabilityServiceTest.java
@@ -71,7 +71,6 @@ class DeviceAvailabilityServiceTest {
         assertEquals(DeviceHealth.READY, deviceAvailabilityService.findDevStatus("scale"));
     }
 
-    // These tests fail because of a known issue, we will revert back when a permanent solution is found
     @Test
     void Test_findDevStatus_FlatbedScanner() {
         //arrange

--- a/src/test/java/com/target/devicemanager/common/DeviceAvailabilityServiceTest.java
+++ b/src/test/java/com/target/devicemanager/common/DeviceAvailabilityServiceTest.java
@@ -72,7 +72,7 @@ class DeviceAvailabilityServiceTest {
     }
 
     // These tests fail because of a known issue, we will revert back when a permanent solution is found
-    /*@Test
+    @Test
     void Test_findDevStatus_FlatbedScanner() {
         //arrange
         DeviceHealth expected = new DeviceHealthResponse("FLATBED", DeviceHealth.NOTREADY).getHealthStatus();
@@ -98,7 +98,7 @@ class DeviceAvailabilityServiceTest {
 
         //assert
         assertEquals(expected, actual);
-    }*/
+    }
 
     @Test
     void Test_findDevStatus_LineDisplay() {

--- a/src/test/java/com/target/devicemanager/components/scanner/ScannerManagerTest.java
+++ b/src/test/java/com/target/devicemanager/components/scanner/ScannerManagerTest.java
@@ -620,9 +620,14 @@ public class ScannerManagerTest {
     void getScannerHealthStatus_HandScanner() {
         //arrange
         List<DeviceHealthResponse> devReady = new ArrayList<>();
-        devReady.add(new DeviceHealthResponse("FLATBED", DeviceHealth.READY));
-        devReady.add(new DeviceHealthResponse("HANDHELD", DeviceHealth.READY));
+        devReady.add(new DeviceHealthResponse("Zebra", DeviceHealth.READY));
+        devReady.add(new DeviceHealthResponse("Honeywell", DeviceHealth.READY));
         Mockito.doReturn(devReady).when(scannerManagerCache).getStatus();
+        Mockito.doReturn("Honeywell").when(mockHandheldScannerDevice).getDeviceName();
+        Mockito.doReturn("HANDHELD").when(mockHandheldScannerDevice).getScannerType();
+        Mockito.doReturn("Zebra").when(mockFlatbedScannerDevice).getDeviceName();
+        Mockito.doReturn("FLATBED").when(mockFlatbedScannerDevice).getScannerType();
+
 
         //act
         DeviceHealth actual = scannerManagerCache.getScannerHealthStatus("HANDHELD");
@@ -634,9 +639,12 @@ public class ScannerManagerTest {
     @Test
     void getScannerHealthStatus_HandheldScanner_missing() {
         //arrange
+        scannerDevices.remove(mockHandheldScannerDevice);
         List<DeviceHealthResponse> devReady = new ArrayList<>();
-        devReady.add(new DeviceHealthResponse("FLATBED", DeviceHealth.READY));
+        devReady.add(new DeviceHealthResponse("Zebra", DeviceHealth.READY));
         Mockito.doReturn(devReady).when(scannerManagerCache).getStatus();
+        Mockito.doReturn("Zebra").when(mockFlatbedScannerDevice).getDeviceName();
+        Mockito.doReturn("FLATBED").when(mockFlatbedScannerDevice).getScannerType();
 
         //act
         DeviceHealth actual = scannerManagerCache.getScannerHealthStatus("HANDHELD");

--- a/src/test/java/com/target/devicemanager/components/scanner/ScannerManagerTest.java
+++ b/src/test/java/com/target/devicemanager/components/scanner/ScannerManagerTest.java
@@ -605,12 +605,16 @@ public class ScannerManagerTest {
     void getScannerHealthStatus_FlatbedScanner() {
         //arrange
         List<DeviceHealthResponse> devReady = new ArrayList<>();
-        devReady.add(new DeviceHealthResponse("FLATBED", DeviceHealth.READY));
-        devReady.add(new DeviceHealthResponse("HANDHELD", DeviceHealth.READY));
+        devReady.add(new DeviceHealthResponse("Zebra", DeviceHealth.READY));
+        devReady.add(new DeviceHealthResponse("Honeywell", DeviceHealth.READY));
         Mockito.doReturn(devReady).when(scannerManagerCache).getStatus();
+        Mockito.doReturn("Honeywell").when(mockHandheldScannerDevice).getDeviceName();
+        Mockito.doReturn("HANDHELD").when(mockHandheldScannerDevice).getScannerType();
+        Mockito.doReturn("Zebra").when(mockFlatbedScannerDevice).getDeviceName();
+        Mockito.doReturn("FLATBED").when(mockFlatbedScannerDevice).getScannerType();
 
         //act
-        DeviceHealth actual = scannerManagerCache.getScannerHealthStatus("HANDHELD");
+        DeviceHealth actual = scannerManagerCache.getScannerHealthStatus("FLATBED");
 
         //assert
         assertEquals(DeviceHealth.READY, actual);


### PR DESCRIPTION
Description of changes:
- added a check for the scanner device name to get accurate health calls for POSCentral

Description of testing:
- Tested on T9401REG0066 for functionality

Please make sure the following changes have been made before creating a pull request.

Update `Description`
- [x] `Change tested on actual device`
- [x] `Changes tested for simulator`
- [x] `Existing device functionality is working fine`
- [x] `Unit Tests Written for Code Changes, and Verified that Coverage is 100% for Modified Files(with the exception of ATM devices)`
