### PR TITLE
PNA-2373 updated how to handle paper near empty

### DIFF
--- a/src/main/java/com/target/devicemanager/components/printer/PrinterDevice.java
+++ b/src/main/java/com/target/devicemanager/components/printer/PrinterDevice.java
@@ -449,6 +449,9 @@ public class PrinterDevice implements StatusUpdateListener{
                 break;
             case POSPrinterConst.PTR_SUE_REC_NEAREMPTY:
                 LOGGER.warn("Status Update: Receipt printer paper near empty");
+                if (getWasPaperEmpty()) {
+                    setWasPaperEmpty(false);
+                }
                 break;
             case POSPrinterConst.PTR_SUE_REC_PAPEROK:
                 LOGGER.debug("Status Update: Receipt paper OK");


### PR DESCRIPTION
Description of changes:
- When the printer status is 'near empty', set the bool wasPaperEmpty according

Description of testing:

Please make sure the following changes have been made before creating a pull request.

Update `Description`
- [x] `Change tested on actual device`
- [x] `Changes tested for simulator`
- [x] `Existing device functionality is working fine`
- [x] `Unit Tests Written for Code Changes, and Verified that Coverage is 100% for Modified Files(with the exception of ATM devices)`
