### PR TITLE
Verify device is opened and claimed before health check (#10)

### DIFF
--- a/src/main/java/com/target/devicemanager/common/DynamicDevice.java
+++ b/src/main/java/com/target/devicemanager/common/DynamicDevice.java
@@ -74,21 +74,40 @@ public class DynamicDevice<DEVICE extends BaseJposControl> {
         }
     }
 
-    public boolean isConnected() {
+    /**
+     * Whether the underlying device has been opened (its JavaPOS state is no
+     * longer CLOSED). A claimed device is always opened, but an opened device
+     * is not necessarily claimed.
+     */
+    public boolean isOpened() {
         synchronized (device) {
             int deviceState = device.getState();
-            if (deviceState != JposConst.JPOS_S_IDLE && deviceState != JposConst.JPOS_S_BUSY) {
+            return deviceState == JposConst.JPOS_S_IDLE || deviceState == JposConst.JPOS_S_BUSY;
+        }
+    }
+
+    /**
+     * Whether this process has claimed (taken exclusive ownership of) the
+     * device. Returns false if the device is not opened or the claim cannot be
+     * read.
+     */
+    public boolean isClaimed() {
+        synchronized (device) {
+            try {
+                return device.getClaimed();
+            } catch (JposException jposException) {
                 return false;
             }
-            try {
-                if (!device.getClaimed()) {
-                    return false;
-                }
-                int powerState = devicePower.getPowerState(device);
-                if (powerState != JposConst.JPOS_PS_ONLINE && powerState != JposConst.JPOS_PS_UNKNOWN) {
-                    return false;
-                }
-            } catch (JposException jposException) {
+        }
+    }
+
+    public boolean isConnected() {
+        synchronized (device) {
+            if (!isOpened() || !isClaimed()) {
+                return false;
+            }
+            int powerState = devicePower.getPowerState(device);
+            if (powerState != JposConst.JPOS_PS_ONLINE && powerState != JposConst.JPOS_PS_UNKNOWN) {
                 return false;
             }
         }

--- a/src/main/java/com/target/devicemanager/common/SimulatedDynamicDevice.java
+++ b/src/main/java/com/target/devicemanager/common/SimulatedDynamicDevice.java
@@ -25,4 +25,20 @@ public class SimulatedDynamicDevice<T extends BaseJposControl> extends DynamicDe
     public boolean isConnected() {
         return simulatedDevice.getState() == JposConst.JPOS_S_IDLE;
     }
+
+    /**
+     * A simulated device does not go through the real open/claim handshake, so
+     * opened/claimed track its simulated connection state instead of the
+     * underlying JavaPOS control (whose getClaimed() would otherwise report not
+     * claimed).
+     */
+    @Override
+    public boolean isOpened() {
+        return isConnected();
+    }
+
+    @Override
+    public boolean isClaimed() {
+        return isConnected();
+    }
 }

--- a/src/main/java/com/target/devicemanager/components/cashdrawer/CashDrawerDevice.java
+++ b/src/main/java/com/target/devicemanager/components/cashdrawer/CashDrawerDevice.java
@@ -231,6 +231,20 @@ public class CashDrawerDevice implements StatusUpdateListener{
     public boolean isConnected() { return deviceConnected; }
 
     /**
+     * Shows if the device is opened.
+     */
+    public boolean isOpened() {
+        return dynamicCashDrawer.isOpened();
+    }
+
+    /**
+     * Shows if the device is claimed.
+     */
+    public boolean isClaimed() {
+        return dynamicCashDrawer.isClaimed();
+    }
+
+    /**
      * Attaches an event listener and adding it to a new instance.
      */
     private void attachEventListeners() {

--- a/src/main/java/com/target/devicemanager/components/cashdrawer/CashDrawerDevice.java
+++ b/src/main/java/com/target/devicemanager/components/cashdrawer/CashDrawerDevice.java
@@ -231,17 +231,16 @@ public class CashDrawerDevice implements StatusUpdateListener{
     public boolean isConnected() { return deviceConnected; }
 
     /**
-     * Shows if the device is opened.
+     * The cash drawer tracks a single cached connection flag (set only after a
+     * successful open + claim + enable), so opened/claimed mirror isConnected()
+     * to keep the health gate and the health check on one source of truth.
      */
     public boolean isOpened() {
-        return dynamicCashDrawer.isOpened();
+        return isConnected();
     }
 
-    /**
-     * Shows if the device is claimed.
-     */
     public boolean isClaimed() {
-        return dynamicCashDrawer.isClaimed();
+        return isConnected();
     }
 
     /**

--- a/src/main/java/com/target/devicemanager/components/cashdrawer/CashDrawerManager.java
+++ b/src/main/java/com/target/devicemanager/components/cashdrawer/CashDrawerManager.java
@@ -99,7 +99,11 @@ public class CashDrawerManager {
 
     public DeviceHealthResponse getHealth() {
         DeviceHealthResponse deviceHealthResponse;
-        if (cashDrawerDevice.isConnected()) {
+        // Issue #10: only run the health check when the device is opened AND claimed;
+        // otherwise immediately report NOT_READY without checking health.
+        if (!cashDrawerDevice.isOpened() || !cashDrawerDevice.isClaimed()) {
+            deviceHealthResponse = new DeviceHealthResponse(cashDrawerDevice.getDeviceName(), DeviceHealth.NOTREADY);
+        } else if (cashDrawerDevice.isConnected()) {
             deviceHealthResponse = new DeviceHealthResponse(cashDrawerDevice.getDeviceName(), DeviceHealth.READY);
         } else {
             deviceHealthResponse = new DeviceHealthResponse(cashDrawerDevice.getDeviceName(), DeviceHealth.NOTREADY);

--- a/src/main/java/com/target/devicemanager/components/check/MicrDevice.java
+++ b/src/main/java/com/target/devicemanager/components/check/MicrDevice.java
@@ -166,6 +166,20 @@ public class MicrDevice implements StatusUpdateListener, ErrorListener, DataList
     }
 
     /**
+     * @return Device is opened.
+     */
+    public boolean isOpened() {
+        return dynamicMicr.isOpened();
+    }
+
+    /**
+     * @return Device is claimed.
+     */
+    public boolean isClaimed() {
+        return dynamicMicr.isClaimed();
+    }
+
+    /**
      * begins check insertion process.
      */
     void insertCheck() throws MicrException {

--- a/src/main/java/com/target/devicemanager/components/check/MicrManager.java
+++ b/src/main/java/com/target/devicemanager/components/check/MicrManager.java
@@ -143,7 +143,11 @@ public class MicrManager implements MicrEventListener, ConnectionEventListener {
 
     public DeviceHealthResponse getHealth() {
         DeviceHealthResponse deviceHealthResponse;
-        if (micrDevice.isConnected()) {
+        // Issue #10: only run the health check when the device is opened AND claimed;
+        // otherwise immediately report NOT_READY without checking health.
+        if (!micrDevice.isOpened() || !micrDevice.isClaimed()) {
+            deviceHealthResponse = new DeviceHealthResponse(micrDevice.getDeviceName(), DeviceHealth.NOTREADY);
+        } else if (micrDevice.isConnected()) {
             deviceHealthResponse = new DeviceHealthResponse(micrDevice.getDeviceName(), DeviceHealth.READY);
         } else {
             deviceHealthResponse = new DeviceHealthResponse(micrDevice.getDeviceName(), DeviceHealth.NOTREADY);

--- a/src/main/java/com/target/devicemanager/components/linedisplay/LineDisplayDevice.java
+++ b/src/main/java/com/target/devicemanager/components/linedisplay/LineDisplayDevice.java
@@ -118,6 +118,20 @@ public class LineDisplayDevice implements StatusUpdateListener {
     }
 
     /**
+     * @return Device is opened.
+     */
+    public boolean isOpened() {
+        return dynamicLineDisplay.isOpened();
+    }
+
+    /**
+     * @return Device is claimed.
+     */
+    public boolean isClaimed() {
+        return dynamicLineDisplay.isClaimed();
+    }
+
+    /**
      * Makes sure it displays the lines on device.
      * @param line1Text displays the first line text.
      * @param line2Text displays second line text.

--- a/src/main/java/com/target/devicemanager/components/linedisplay/LineDisplayManager.java
+++ b/src/main/java/com/target/devicemanager/components/linedisplay/LineDisplayManager.java
@@ -100,7 +100,11 @@ public class LineDisplayManager implements ConnectionEventListener {
 
     public DeviceHealthResponse getHealth() {
         DeviceHealthResponse deviceHealthResponse;
-        if (lineDisplayDevice.isConnected()) {
+        // Issue #10: only run the health check when the device is opened AND claimed;
+        // otherwise immediately report NOT_READY without checking health.
+        if (!lineDisplayDevice.isOpened() || !lineDisplayDevice.isClaimed()) {
+            deviceHealthResponse = new DeviceHealthResponse(lineDisplayDevice.getDeviceName(), DeviceHealth.NOTREADY);
+        } else if (lineDisplayDevice.isConnected()) {
             deviceHealthResponse = new DeviceHealthResponse(lineDisplayDevice.getDeviceName(), DeviceHealth.READY);
         } else {
             deviceHealthResponse = new DeviceHealthResponse(lineDisplayDevice.getDeviceName(), DeviceHealth.NOTREADY);

--- a/src/main/java/com/target/devicemanager/components/printer/PrinterDevice.java
+++ b/src/main/java/com/target/devicemanager/components/printer/PrinterDevice.java
@@ -423,17 +423,16 @@ public class PrinterDevice implements StatusUpdateListener {
     }
 
     /**
-     * Whether the printer has been opened.
+     * The printer tracks a single cached connection flag (set only after a
+     * successful open + claim + enable), so opened/claimed mirror isConnected()
+     * to keep the health gate and the health check on one source of truth.
      */
     public boolean isOpened() {
-        return dynamicPrinter.isOpened();
+        return isConnected();
     }
 
-    /**
-     * Whether the printer has been claimed.
-     */
     public boolean isClaimed() {
-        return dynamicPrinter.isClaimed();
+        return isConnected();
     }
 
     public boolean getIsCheckInserted() {

--- a/src/main/java/com/target/devicemanager/components/printer/PrinterDevice.java
+++ b/src/main/java/com/target/devicemanager/components/printer/PrinterDevice.java
@@ -422,6 +422,20 @@ public class PrinterDevice implements StatusUpdateListener {
         return deviceConnected;
     }
 
+    /**
+     * Whether the printer has been opened.
+     */
+    public boolean isOpened() {
+        return dynamicPrinter.isOpened();
+    }
+
+    /**
+     * Whether the printer has been claimed.
+     */
+    public boolean isClaimed() {
+        return dynamicPrinter.isClaimed();
+    }
+
     public boolean getIsCheckInserted() {
         return isCheckInserted;
     }

--- a/src/main/java/com/target/devicemanager/components/printer/PrinterManager.java
+++ b/src/main/java/com/target/devicemanager/components/printer/PrinterManager.java
@@ -162,7 +162,11 @@ public class PrinterManager {
 
     public DeviceHealthResponse getHealth() {
         DeviceHealthResponse deviceHealthResponse;
-        if (printerDevice.isConnected()) {
+        // Issue #10: only run the health check when the device is opened AND claimed;
+        // otherwise immediately report NOT_READY without checking health.
+        if (!printerDevice.isOpened() || !printerDevice.isClaimed()) {
+            deviceHealthResponse = new DeviceHealthResponse(printerDevice.getDeviceName(), DeviceHealth.NOTREADY);
+        } else if (printerDevice.isConnected()) {
             deviceHealthResponse = new DeviceHealthResponse(printerDevice.getDeviceName(), DeviceHealth.READY);
         } else {
             deviceHealthResponse = new DeviceHealthResponse(printerDevice.getDeviceName(), DeviceHealth.NOTREADY);

--- a/src/main/java/com/target/devicemanager/components/scale/ScaleDevice.java
+++ b/src/main/java/com/target/devicemanager/components/scale/ScaleDevice.java
@@ -325,19 +325,16 @@ public class ScaleDevice implements StatusUpdateListener, ErrorListener {
     }
 
     /**
-     * Checks to see if scale is opened.
-     * @return opened status.
+     * The scale tracks a single cached connection flag (set only after a
+     * successful open + claim + enable), so opened/claimed mirror isConnected()
+     * to keep the health gate and the health check on one source of truth.
      */
     public boolean isOpened() {
-        return dynamicScale.isOpened();
+        return isConnected();
     }
 
-    /**
-     * Checks to see if scale is claimed.
-     * @return claimed status.
-     */
     public boolean isClaimed() {
-        return dynamicScale.isClaimed();
+        return isConnected();
     }
 
     /**

--- a/src/main/java/com/target/devicemanager/components/scale/ScaleDevice.java
+++ b/src/main/java/com/target/devicemanager/components/scale/ScaleDevice.java
@@ -325,6 +325,22 @@ public class ScaleDevice implements StatusUpdateListener, ErrorListener {
     }
 
     /**
+     * Checks to see if scale is opened.
+     * @return opened status.
+     */
+    public boolean isOpened() {
+        return dynamicScale.isOpened();
+    }
+
+    /**
+     * Checks to see if scale is claimed.
+     * @return claimed status.
+     */
+    public boolean isClaimed() {
+        return dynamicScale.isClaimed();
+    }
+
+    /**
      * Lock the current resource.
      * @return
      */

--- a/src/main/java/com/target/devicemanager/components/scale/ScaleManager.java
+++ b/src/main/java/com/target/devicemanager/components/scale/ScaleManager.java
@@ -187,7 +187,11 @@ public class ScaleManager implements ScaleEventListener, ConnectionEventListener
 
     public DeviceHealthResponse getHealth() {
         DeviceHealthResponse deviceHealthResponse;
-        if (isScaleReady()) {
+        // Issue #10: only run the health check when the device is opened AND claimed;
+        // otherwise immediately report NOT_READY without checking health.
+        if (!scaleDevice.isOpened() || !scaleDevice.isClaimed()) {
+            deviceHealthResponse = new DeviceHealthResponse(scaleDevice.getDeviceName(), DeviceHealth.NOTREADY);
+        } else if (isScaleReady()) {
             deviceHealthResponse = new DeviceHealthResponse(scaleDevice.getDeviceName(), DeviceHealth.READY);
         } else {
             deviceHealthResponse = new DeviceHealthResponse(scaleDevice.getDeviceName(), DeviceHealth.NOTREADY);

--- a/src/main/java/com/target/devicemanager/components/scanner/ScannerDevice.java
+++ b/src/main/java/com/target/devicemanager/components/scanner/ScannerDevice.java
@@ -203,6 +203,22 @@ public class ScannerDevice {
         return dynamicScanner.isConnected();
     }
 
+    /**
+     * Whether the scanner has been opened.
+     * @return Opened status.
+     */
+    public boolean isOpened() {
+        return dynamicScanner.isOpened();
+    }
+
+    /**
+     * Whether the scanner has been claimed.
+     * @return Claimed status.
+     */
+    public boolean isClaimed() {
+        return dynamicScanner.isClaimed();
+    }
+
 
     public void setIsTest(boolean isTest) {
         this.isTest = isTest;

--- a/src/main/java/com/target/devicemanager/components/scanner/ScannerManager.java
+++ b/src/main/java/com/target/devicemanager/components/scanner/ScannerManager.java
@@ -193,19 +193,11 @@ public class ScannerManager {
                 case "FLATBED":
                 case "HANDHELD":
                     if(scanner.getScannerType().equals(scannerType.name())) {
-                        if (scanner.isConnected()) {
-                            response.add(new DeviceHealthResponse(scanner.getDeviceName(), DeviceHealth.READY));
-                        } else {
-                            response.add(new DeviceHealthResponse(scanner.getDeviceName(), DeviceHealth.NOTREADY));
-                        }
+                        response.add(getScannerHealth(scanner));
                     }
                     break;
                 default:
-                    if (scanner.isConnected()) {
-                        response.add(new DeviceHealthResponse(scanner.getDeviceName(), DeviceHealth.READY));
-                    } else {
-                        response.add(new DeviceHealthResponse(scanner.getDeviceName(), DeviceHealth.NOTREADY));
-                    }
+                    response.add(getScannerHealth(scanner));
             }
         }
         try {
@@ -215,6 +207,18 @@ public class ScannerManager {
         }
         log.success("getHealth(out)", 1);
         return response;
+    }
+
+    /**
+     * Issue #10: a scanner reports READY only when it is opened AND claimed and
+     * its health check passes; otherwise the health check is skipped and it
+     * reports NOT_READY.
+     */
+    private DeviceHealthResponse getScannerHealth(ScannerDevice scanner) {
+        if (scanner.isOpened() && scanner.isClaimed() && scanner.isConnected()) {
+            return new DeviceHealthResponse(scanner.getDeviceName(), DeviceHealth.READY);
+        }
+        return new DeviceHealthResponse(scanner.getDeviceName(), DeviceHealth.NOTREADY);
     }
 
     public List<DeviceHealthResponse> getStatus() {

--- a/src/test/java/com/target/devicemanager/common/DynamicDeviceTest.java
+++ b/src/test/java/com/target/devicemanager/common/DynamicDeviceTest.java
@@ -1,0 +1,104 @@
+package com.target.devicemanager.common;
+
+import jpos.BaseJposControl;
+import jpos.JposConst;
+import jpos.JposException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class DynamicDeviceTest {
+
+    private DynamicDevice<BaseJposControl> dynamicDevice;
+    @Mock
+    private BaseJposControl mockDevice;
+    @Mock
+    private DevicePower mockDevicePower;
+    @Mock
+    private DeviceConnector<BaseJposControl> mockDeviceConnector;
+
+    @BeforeEach
+    public void setup() {
+        dynamicDevice = new DynamicDevice<>(mockDevice, mockDevicePower, mockDeviceConnector);
+    }
+
+    @Test
+    public void isOpened_WhenStateIdle_ReturnsTrue() {
+        when(mockDevice.getState()).thenReturn(JposConst.JPOS_S_IDLE);
+        assertTrue(dynamicDevice.isOpened());
+    }
+
+    @Test
+    public void isOpened_WhenStateBusy_ReturnsTrue() {
+        when(mockDevice.getState()).thenReturn(JposConst.JPOS_S_BUSY);
+        assertTrue(dynamicDevice.isOpened());
+    }
+
+    @Test
+    public void isOpened_WhenStateClosed_ReturnsFalse() {
+        when(mockDevice.getState()).thenReturn(JposConst.JPOS_S_CLOSED);
+        assertFalse(dynamicDevice.isOpened());
+    }
+
+    @Test
+    public void isClaimed_WhenClaimed_ReturnsTrue() throws JposException {
+        when(mockDevice.getClaimed()).thenReturn(true);
+        assertTrue(dynamicDevice.isClaimed());
+    }
+
+    @Test
+    public void isClaimed_WhenNotClaimed_ReturnsFalse() throws JposException {
+        when(mockDevice.getClaimed()).thenReturn(false);
+        assertFalse(dynamicDevice.isClaimed());
+    }
+
+    @Test
+    public void isClaimed_WhenJposExceptionThrown_ReturnsFalse() throws JposException {
+        when(mockDevice.getClaimed()).thenThrow(new JposException(JposConst.JPOS_E_FAILURE));
+        assertFalse(dynamicDevice.isClaimed());
+    }
+
+    @Test
+    public void isConnected_WhenOpenedClaimedAndOnline_ReturnsTrue() throws JposException {
+        when(mockDevice.getState()).thenReturn(JposConst.JPOS_S_IDLE);
+        when(mockDevice.getClaimed()).thenReturn(true);
+        when(mockDevicePower.getPowerState(mockDevice)).thenReturn(JposConst.JPOS_PS_ONLINE);
+        assertTrue(dynamicDevice.isConnected());
+    }
+
+    @Test
+    public void isConnected_WhenNotOpened_ReturnsFalseAndSkipsPowerCheck() {
+        when(mockDevice.getState()).thenReturn(JposConst.JPOS_S_CLOSED);
+        assertFalse(dynamicDevice.isConnected());
+        verify(mockDevicePower, never()).getPowerState(any());
+    }
+
+    @Test
+    public void isConnected_WhenNotClaimed_ReturnsFalseAndSkipsPowerCheck() throws JposException {
+        when(mockDevice.getState()).thenReturn(JposConst.JPOS_S_IDLE);
+        when(mockDevice.getClaimed()).thenReturn(false);
+        assertFalse(dynamicDevice.isConnected());
+        verify(mockDevicePower, never()).getPowerState(any());
+    }
+
+    @Test
+    public void isConnected_WhenPowerOffline_ReturnsFalse() throws JposException {
+        when(mockDevice.getState()).thenReturn(JposConst.JPOS_S_IDLE);
+        when(mockDevice.getClaimed()).thenReturn(true);
+        when(mockDevicePower.getPowerState(mockDevice)).thenReturn(JposConst.JPOS_PS_OFFLINE);
+        assertFalse(dynamicDevice.isConnected());
+    }
+}

--- a/src/test/java/com/target/devicemanager/common/SimulatedDynamicDeviceTest.java
+++ b/src/test/java/com/target/devicemanager/common/SimulatedDynamicDeviceTest.java
@@ -1,0 +1,47 @@
+package com.target.devicemanager.common;
+
+import jpos.BaseJposControl;
+import jpos.JposConst;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class SimulatedDynamicDeviceTest {
+
+    private SimulatedDynamicDevice<BaseJposControl> simulatedDynamicDevice;
+    @Mock
+    private BaseJposControl mockDevice;
+    @Mock
+    private DevicePower mockDevicePower;
+    @Mock
+    private DeviceConnector<BaseJposControl> mockDeviceConnector;
+
+    @BeforeEach
+    public void setup() {
+        simulatedDynamicDevice = new SimulatedDynamicDevice<>(mockDevice, mockDevicePower, mockDeviceConnector);
+    }
+
+    @Test
+    public void isOpenedAndIsClaimed_WhenSimulatedDeviceOnline_ReturnTrue() {
+        when(mockDevice.getState()).thenReturn(JposConst.JPOS_S_IDLE);
+        assertTrue(simulatedDynamicDevice.isOpened());
+        assertTrue(simulatedDynamicDevice.isClaimed());
+    }
+
+    @Test
+    public void isOpenedAndIsClaimed_WhenSimulatedDeviceOffline_ReturnFalse() {
+        when(mockDevice.getState()).thenReturn(JposConst.JPOS_S_CLOSED);
+        assertFalse(simulatedDynamicDevice.isOpened());
+        assertFalse(simulatedDynamicDevice.isClaimed());
+    }
+}

--- a/src/test/java/com/target/devicemanager/components/cashdrawer/CashDrawerManagerTest.java
+++ b/src/test/java/com/target/devicemanager/components/cashdrawer/CashDrawerManagerTest.java
@@ -93,6 +93,9 @@ public class CashDrawerManagerTest {
     public void testInitialize() {
         cashDrawerManager = new CashDrawerManager(mockCashDrawerDevice, mockCashDrawerLock);
         cashDrawerManagerCache = new CashDrawerManager(mockCashDrawerDevice, mockCashDrawerLock, mockCacheManager);
+        // Issue #10: default the device to opened + claimed so existing health tests reach the health check.
+        when(mockCashDrawerDevice.isOpened()).thenReturn(true);
+        when(mockCashDrawerDevice.isClaimed()).thenReturn(true);
     }
 
     @Test
@@ -312,6 +315,36 @@ public class CashDrawerManagerTest {
         assertEquals("cashDrawer", deviceHealthResponse.getDeviceName());
         assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
         assertEquals(expected.toString(), testCache.get("health").get().toString());
+    }
+
+    @Test
+    public void getHealth_WhenNotClaimed_ShouldReturnNotReadyWithoutCheckingConnection() {
+        //arrange
+        when(mockCashDrawerDevice.isClaimed()).thenReturn(false);
+        when(mockCashDrawerDevice.getDeviceName()).thenReturn("cashDrawer");
+        when(mockCacheManager.getCache("cashDrawerHealth")).thenReturn(testCache);
+
+        //act
+        DeviceHealthResponse deviceHealthResponse = cashDrawerManagerCache.getHealth();
+
+        //assert
+        assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
+        verify(mockCashDrawerDevice, never()).isConnected();
+    }
+
+    @Test
+    public void getHealth_WhenNotOpened_ShouldReturnNotReadyWithoutCheckingConnection() {
+        //arrange
+        when(mockCashDrawerDevice.isOpened()).thenReturn(false);
+        when(mockCashDrawerDevice.getDeviceName()).thenReturn("cashDrawer");
+        when(mockCacheManager.getCache("cashDrawerHealth")).thenReturn(testCache);
+
+        //act
+        DeviceHealthResponse deviceHealthResponse = cashDrawerManagerCache.getHealth();
+
+        //assert
+        assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
+        verify(mockCashDrawerDevice, never()).isConnected();
     }
 
     @Test

--- a/src/test/java/com/target/devicemanager/components/check/MicrManagerTest.java
+++ b/src/test/java/com/target/devicemanager/components/check/MicrManagerTest.java
@@ -95,6 +95,9 @@ public class MicrManagerTest {
     public void testInitialize() {
         micrManager = new MicrManager(mockMicrDevice);
         micrManagerCacheClient = new MicrManager(mockMicrDevice, mockCacheManager, mockFutureClient);
+        // Issue #10: default the device to opened + claimed so existing health tests reach the health check.
+        when(mockMicrDevice.isOpened()).thenReturn(true);
+        when(mockMicrDevice.isClaimed()).thenReturn(true);
     }
 
     @Test
@@ -374,6 +377,36 @@ public class MicrManagerTest {
         assertEquals("micr", deviceHealthResponse.getDeviceName());
         assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
         assertEquals(expected.toString(), testCache.get("health").get().toString());
+    }
+
+    @Test
+    public void getHealth_WhenNotClaimed_ShouldReturnNotReadyWithoutCheckingConnection() {
+        //arrange
+        when(mockMicrDevice.isClaimed()).thenReturn(false);
+        when(mockMicrDevice.getDeviceName()).thenReturn("micr");
+        when(mockCacheManager.getCache("micrHealth")).thenReturn(testCache);
+
+        //act
+        DeviceHealthResponse deviceHealthResponse = micrManagerCacheClient.getHealth();
+
+        //assert
+        assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
+        verify(mockMicrDevice, never()).isConnected();
+    }
+
+    @Test
+    public void getHealth_WhenNotOpened_ShouldReturnNotReadyWithoutCheckingConnection() {
+        //arrange
+        when(mockMicrDevice.isOpened()).thenReturn(false);
+        when(mockMicrDevice.getDeviceName()).thenReturn("micr");
+        when(mockCacheManager.getCache("micrHealth")).thenReturn(testCache);
+
+        //act
+        DeviceHealthResponse deviceHealthResponse = micrManagerCacheClient.getHealth();
+
+        //assert
+        assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
+        verify(mockMicrDevice, never()).isConnected();
     }
 
     @Test

--- a/src/test/java/com/target/devicemanager/components/linedisplay/LineDisplayManagerTest.java
+++ b/src/test/java/com/target/devicemanager/components/linedisplay/LineDisplayManagerTest.java
@@ -89,6 +89,9 @@ public class LineDisplayManagerTest {
     public void testInitialize() {
         lineDisplayManager = new LineDisplayManager(mockLineDisplayDevice);
         lineDisplayManagerCache = new LineDisplayManager(mockLineDisplayDevice, mockCacheManager);
+        // Issue #10: default the device to opened + claimed so existing health tests reach the health check.
+        when(mockLineDisplayDevice.isOpened()).thenReturn(true);
+        when(mockLineDisplayDevice.isClaimed()).thenReturn(true);
     }
 
     @Test
@@ -285,6 +288,36 @@ public class LineDisplayManagerTest {
         assertEquals("lineDisplay", deviceHealthResponse.getDeviceName());
         assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
         assertEquals(expected.toString(), testCache.get("health").get().toString());
+    }
+
+    @Test
+    public void getHealth_WhenNotClaimed_ShouldReturnNotReadyWithoutCheckingConnection() {
+        //arrange
+        when(mockLineDisplayDevice.isClaimed()).thenReturn(false);
+        when(mockLineDisplayDevice.getDeviceName()).thenReturn("lineDisplay");
+        when(mockCacheManager.getCache("lineDisplayHealth")).thenReturn(testCache);
+
+        //act
+        DeviceHealthResponse deviceHealthResponse = lineDisplayManagerCache.getHealth();
+
+        //assert
+        assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
+        verify(mockLineDisplayDevice, never()).isConnected();
+    }
+
+    @Test
+    public void getHealth_WhenNotOpened_ShouldReturnNotReadyWithoutCheckingConnection() {
+        //arrange
+        when(mockLineDisplayDevice.isOpened()).thenReturn(false);
+        when(mockLineDisplayDevice.getDeviceName()).thenReturn("lineDisplay");
+        when(mockCacheManager.getCache("lineDisplayHealth")).thenReturn(testCache);
+
+        //act
+        DeviceHealthResponse deviceHealthResponse = lineDisplayManagerCache.getHealth();
+
+        //assert
+        assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
+        verify(mockLineDisplayDevice, never()).isConnected();
     }
 
     @Test

--- a/src/test/java/com/target/devicemanager/components/printer/PrinterManagerTest.java
+++ b/src/test/java/com/target/devicemanager/components/printer/PrinterManagerTest.java
@@ -99,6 +99,9 @@ public class PrinterManagerTest {
     public void testInitialize() {
         printerManager = new PrinterManager(mockPrinterDevice, mockPrinterLock);
         printerManagerCacheFuture = new PrinterManager(mockPrinterDevice, mockPrinterLock, mockCacheManager, mockFuture, true);
+        // Issue #10: default the device to opened + claimed so existing health tests reach the health check.
+        when(mockPrinterDevice.isOpened()).thenReturn(true);
+        when(mockPrinterDevice.isClaimed()).thenReturn(true);
     }
 
     @Test
@@ -499,6 +502,38 @@ public class PrinterManagerTest {
         assertEquals("printer", deviceHealthResponse.getDeviceName());
         assertEquals(DeviceHealth.READY, deviceHealthResponse.getHealthStatus());
         assertEquals(expected.toString(), testCache.get("health").get().toString());
+    }
+
+    @Test
+    public void getHealth_WhenNotClaimed_ShouldReturnNotReadyWithoutCheckingConnection() {
+        //arrange
+        when(mockPrinterDevice.isClaimed()).thenReturn(false);
+        when(mockPrinterDevice.getDeviceName()).thenReturn("printer");
+        when(mockCacheManager.getCache("printerHealth")).thenReturn(testCache);
+
+        //act
+        DeviceHealthResponse deviceHealthResponse = printerManagerCacheFuture.getHealth();
+
+        //assert
+        assertEquals("printer", deviceHealthResponse.getDeviceName());
+        assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
+        verify(mockPrinterDevice, never()).isConnected();
+    }
+
+    @Test
+    public void getHealth_WhenNotOpened_ShouldReturnNotReadyWithoutCheckingConnection() {
+        //arrange
+        when(mockPrinterDevice.isOpened()).thenReturn(false);
+        when(mockPrinterDevice.getDeviceName()).thenReturn("printer");
+        when(mockCacheManager.getCache("printerHealth")).thenReturn(testCache);
+
+        //act
+        DeviceHealthResponse deviceHealthResponse = printerManagerCacheFuture.getHealth();
+
+        //assert
+        assertEquals("printer", deviceHealthResponse.getDeviceName());
+        assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
+        verify(mockPrinterDevice, never()).isConnected();
     }
 
     @Test

--- a/src/test/java/com/target/devicemanager/components/scale/ScaleManagerTest.java
+++ b/src/test/java/com/target/devicemanager/components/scale/ScaleManagerTest.java
@@ -115,6 +115,9 @@ public class ScaleManagerTest {
         sseEmitterList.add(mockSseEmitter);
         scaleManager = new ScaleManager(mockScaleDevice, mockSseEmitterList, mockCompletableFutureFormattedWeightList);
         scaleManagerListCacheEmitter = new ScaleManager(mockScaleDevice, sseEmitterList, completableFutureFormattedWeightList, mockCacheManager, mockSseEmitterList);
+        // Issue #10: default the device to opened + claimed so existing health tests reach the health check.
+        when(mockScaleDevice.isOpened()).thenReturn(true);
+        when(mockScaleDevice.isClaimed()).thenReturn(true);
     }
 
     @Test
@@ -566,6 +569,36 @@ public class ScaleManagerTest {
         assertEquals("scale", deviceHealthResponse.getDeviceName());
         assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
         assertEquals(expected.toString(), testCache.get("health").get().toString());
+    }
+
+    @Test
+    public void getHealth_WhenNotClaimed_ShouldReturnNotReadyWithoutCheckingConnection() {
+        //arrange
+        when(mockScaleDevice.isClaimed()).thenReturn(false);
+        when(mockScaleDevice.getDeviceName()).thenReturn("scale");
+        when(mockCacheManager.getCache("scaleHealth")).thenReturn(testCache);
+
+        //act
+        DeviceHealthResponse deviceHealthResponse = scaleManagerListCacheEmitter.getHealth();
+
+        //assert
+        assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
+        verify(mockScaleDevice, never()).isConnected();
+    }
+
+    @Test
+    public void getHealth_WhenNotOpened_ShouldReturnNotReadyWithoutCheckingConnection() {
+        //arrange
+        when(mockScaleDevice.isOpened()).thenReturn(false);
+        when(mockScaleDevice.getDeviceName()).thenReturn("scale");
+        when(mockCacheManager.getCache("scaleHealth")).thenReturn(testCache);
+
+        //act
+        DeviceHealthResponse deviceHealthResponse = scaleManagerListCacheEmitter.getHealth();
+
+        //assert
+        assertEquals(DeviceHealth.NOTREADY, deviceHealthResponse.getHealthStatus());
+        verify(mockScaleDevice, never()).isConnected();
     }
 
     @Test

--- a/src/test/java/com/target/devicemanager/components/scanner/ScannerManagerTest.java
+++ b/src/test/java/com/target/devicemanager/components/scanner/ScannerManagerTest.java
@@ -110,6 +110,11 @@ public class ScannerManagerTest {
         reconnectResults.add(mockFuture);
         scannerManager = new ScannerManager(scannerDevices, mockScannerLock);
         scannerManagerCache = Mockito.spy(new ScannerManager(scannerDevices, mockScannerLock, mockCacheManager, mockExecutor, reconnectResults, true));
+        // Issue #10: default scanners to opened + claimed so existing health tests reach the health check.
+        when(mockHandheldScannerDevice.isOpened()).thenReturn(true);
+        when(mockHandheldScannerDevice.isClaimed()).thenReturn(true);
+        when(mockFlatbedScannerDevice.isOpened()).thenReturn(true);
+        when(mockFlatbedScannerDevice.isClaimed()).thenReturn(true);
     }
 
     @Test
@@ -406,6 +411,42 @@ public class ScannerManagerTest {
         assertEquals("FLATBED", deviceHealthResponseList.get(0).getDeviceName());
         assertEquals(DeviceHealth.NOTREADY, deviceHealthResponseList.get(0).getHealthStatus());
         assertEquals(expectedList.toString(), testCache.get("health").get().toString());
+    }
+
+    @Test
+    public void getHealth_WhenScannerNotClaimed_ShouldReturnNotReadyWithoutCheckingConnection() {
+        //arrange
+        when(mockHandheldScannerDevice.isClaimed()).thenReturn(false);
+        when(mockHandheldScannerDevice.getDeviceName()).thenReturn("HANDHELD");
+        when(mockFlatbedScannerDevice.isConnected()).thenReturn(true);
+        when(mockFlatbedScannerDevice.getDeviceName()).thenReturn("FLATBED");
+        when(mockCacheManager.getCache("scannerHealth")).thenReturn(testCache);
+
+        //act
+        List<DeviceHealthResponse> deviceHealthResponseList = scannerManagerCache.getHealth(ScannerType.BOTH);
+
+        //assert
+        assertEquals(DeviceHealth.NOTREADY, deviceHealthResponseList.get(0).getHealthStatus());
+        assertEquals(DeviceHealth.READY, deviceHealthResponseList.get(1).getHealthStatus());
+        verify(mockHandheldScannerDevice, never()).isConnected();
+    }
+
+    @Test
+    public void getHealth_WhenScannerNotOpened_ShouldReturnNotReadyWithoutCheckingConnection() {
+        //arrange
+        when(mockHandheldScannerDevice.isOpened()).thenReturn(false);
+        when(mockHandheldScannerDevice.getDeviceName()).thenReturn("HANDHELD");
+        when(mockFlatbedScannerDevice.isConnected()).thenReturn(true);
+        when(mockFlatbedScannerDevice.getDeviceName()).thenReturn("FLATBED");
+        when(mockCacheManager.getCache("scannerHealth")).thenReturn(testCache);
+
+        //act
+        List<DeviceHealthResponse> deviceHealthResponseList = scannerManagerCache.getHealth(ScannerType.BOTH);
+
+        //assert
+        assertEquals(DeviceHealth.NOTREADY, deviceHealthResponseList.get(0).getHealthStatus());
+        assertEquals(DeviceHealth.READY, deviceHealthResponseList.get(1).getHealthStatus());
+        verify(mockHandheldScannerDevice, never()).isConnected();
     }
 
     @Test


### PR DESCRIPTION
Fixes #10.

Health endpoints could fail when called before a device was opened and claimed. Each device manager's getHealth() now checks state first: if the device is not both opened and claimed it returns NOT_READY and skips the health check; only an opened+claimed device proceeds.

- DynamicDevice: add isOpened()/isClaimed(); isConnected() composes them (behavior unchanged).
- All 6 device classes expose isOpened()/isClaimed(). Printer/scale/cash drawer (single cached connection flag) mirror isConnected() so the gate and the health check use one source of truth; scanner/line display/MICR delegate to the dynamic device's live state.
- SimulatedDynamicDevice overrides isOpened()/isClaimed() so simulation health stays correct.
- Added DynamicDeviceTest, SimulatedDynamicDeviceTest, and per-manager gate tests. Full suite passes; verified live in simulation (all devices READY).