### PR TITLE
Use SimulatedDynamicDevice for MICR and line display simulators (#11)

### DIFF
--- a/src/main/java/com/target/devicemanager/components/check/MicrConfig.java
+++ b/src/main/java/com/target/devicemanager/components/check/MicrConfig.java
@@ -4,6 +4,7 @@ import com.target.devicemanager.common.DeviceAvailabilitySingleton;
 import com.target.devicemanager.common.DeviceConnector;
 import com.target.devicemanager.common.DevicePower;
 import com.target.devicemanager.common.DynamicDevice;
+import com.target.devicemanager.common.SimulatedDynamicDevice;
 import com.target.devicemanager.components.check.simulator.SimulatedJposMicr;
 import com.target.devicemanager.configuration.ApplicationConfig;
 import jpos.MICR;
@@ -32,7 +33,7 @@ class MicrConfig {
         JposEntryRegistry deviceRegistry = JposServiceLoader.getManager().getEntryRegistry();
 
         if (applicationConfig.IsSimulationMode()) {
-            dynamicMicr = new DynamicDevice<>(simulatedMicr, new DevicePower(), new DeviceConnector<>(simulatedMicr, deviceRegistry));
+            dynamicMicr = new SimulatedDynamicDevice<>(simulatedMicr, new DevicePower(), new DeviceConnector<>(simulatedMicr, deviceRegistry));
         } else {
             MICR micr = new MICR();
             dynamicMicr = new DynamicDevice<>(micr, new DevicePower(), new DeviceConnector<>(micr, deviceRegistry));

--- a/src/main/java/com/target/devicemanager/components/check/simulator/SimulatedJposMicr.java
+++ b/src/main/java/com/target/devicemanager/components/check/simulator/SimulatedJposMicr.java
@@ -33,11 +33,6 @@ public class SimulatedJposMicr extends MICR {
     }
 
     @Override
-    public boolean getClaimed() {
-        return true;
-    }
-
-    @Override
     public int getState() {
         return simulatorState == SimulatorState.ONLINE ? JposConst.JPOS_S_IDLE : JposConst.JPOS_S_CLOSED;
     }

--- a/src/main/java/com/target/devicemanager/components/linedisplay/LineDisplayConfig.java
+++ b/src/main/java/com/target/devicemanager/components/linedisplay/LineDisplayConfig.java
@@ -30,7 +30,7 @@ class LineDisplayConfig {
         JposEntryRegistry deviceRegistry = JposServiceLoader.getManager().getEntryRegistry();
 
         if (applicationConfig.IsSimulationMode()) {
-            dynamicLineDisplay = new DynamicDevice<>(simulatedLineDisplay, new DevicePower(), new DeviceConnector<>(simulatedLineDisplay, deviceRegistry));
+            dynamicLineDisplay = new SimulatedDynamicDevice<>(simulatedLineDisplay, new DevicePower(), new DeviceConnector<>(simulatedLineDisplay, deviceRegistry));
         } else {
             LineDisplay lineDisplay = new LineDisplay();
             dynamicLineDisplay = new DynamicDevice<>(lineDisplay, new DevicePower(), new DeviceConnector<>(lineDisplay, deviceRegistry ));

--- a/src/main/java/com/target/devicemanager/components/linedisplay/simulator/SimulatedJposLineDisplay.java
+++ b/src/main/java/com/target/devicemanager/components/linedisplay/simulator/SimulatedJposLineDisplay.java
@@ -42,11 +42,6 @@ public class SimulatedJposLineDisplay extends LineDisplay  {
     }
 
     @Override
-    public boolean getClaimed() {
-        return true;
-    }
-
-    @Override
     public int getCapPowerReporting() {
         return JPOS_PR_STANDARD;
     }


### PR DESCRIPTION
Fixes #11.

MICR and line display were the only devices still wiring their simulators through plain DynamicDevice, each faking getClaimed()=true in the simulator to satisfy the connection check. Switch both to SimulatedDynamicDevice like the other four devices and drop the now-unused getClaimed() overrides. Full suite passes; verified live in simulation (MICR and line display report READY).