### PR TITLE
Fix confirmout.json handling for missing/malformed files (#16)

### DIFF
--- a/src/main/java/com/target/devicemanager/common/entities/DeviceErrorStatusResponse.java
+++ b/src/main/java/com/target/devicemanager/common/entities/DeviceErrorStatusResponse.java
@@ -20,24 +20,29 @@ public class DeviceErrorStatusResponse {
     private static List<DeviceErrorStatus> deviceErrorStatuses;
 
     private DeviceErrorStatusResponse(){
-        deviceErrorStatuses = new CopyOnWriteArrayList<>();
-        ObjectMapper objectMapper = new ObjectMapper();
-        File jsonConfirm = new File("/var/tmp/CONFIRMOUT/confirmout.json");
-        if(jsonConfirm.exists() && jsonConfirm.isFile()){
-            JsonNode rootDevNode = null;
-            try {
-                rootDevNode = objectMapper.readTree(jsonConfirm);
-            } catch (IOException ioException) {
-                log.failure("Error in parsing confirmout", 17, ioException);
-            }
-            Iterator<String> fieldNames = rootDevNode.fieldNames();
+        deviceErrorStatuses = loadDeviceErrorStatuses(new File("/var/tmp/CONFIRMOUT/confirmout.json"));
+    }
 
-            while(fieldNames.hasNext()){
-                deviceErrorStatuses.add(new DeviceErrorStatus(fieldNames.next(), false, null));
-            }
-        } else {
-            log.failure("JSON is in wrong format", 17, null);
+    static List<DeviceErrorStatus> loadDeviceErrorStatuses(File jsonConfirm){
+        List<DeviceErrorStatus> statuses = new CopyOnWriteArrayList<>();
+        if(jsonConfirm == null || !jsonConfirm.exists() || !jsonConfirm.isFile()){
+            log.failure("confirmout.json not found at " + (jsonConfirm == null ? "null" : jsonConfirm.getPath()), 17, null);
+            return statuses;
         }
+
+        JsonNode rootDevNode;
+        try {
+            rootDevNode = new ObjectMapper().readTree(jsonConfirm);
+        } catch (IOException ioException) {
+            log.failure("JSON is in wrong format", 17, ioException);
+            return statuses;
+        }
+
+        Iterator<String> fieldNames = rootDevNode.fieldNames();
+        while(fieldNames.hasNext()){
+            statuses.add(new DeviceErrorStatus(fieldNames.next(), false, null));
+        }
+        return statuses;
     }
 
     public static List<DeviceErrorStatus> getDeviceErrorStatusResponse(){

--- a/src/test/java/com/target/devicemanager/common/entities/DeviceErrorStatusResponseTest.java
+++ b/src/test/java/com/target/devicemanager/common/entities/DeviceErrorStatusResponseTest.java
@@ -1,0 +1,58 @@
+package com.target.devicemanager.common.entities;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DeviceErrorStatusResponseTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void loadDeviceErrorStatuses_WhenFileMissing_ReturnsEmptyList() {
+        File missing = tempDir.resolve("confirmout.json").toFile();
+
+        List<DeviceErrorStatus> result = DeviceErrorStatusResponse.loadDeviceErrorStatuses(missing);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void loadDeviceErrorStatuses_WhenNull_ReturnsEmptyList() {
+        List<DeviceErrorStatus> result = DeviceErrorStatusResponse.loadDeviceErrorStatuses(null);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void loadDeviceErrorStatuses_WhenMalformedJson_ReturnsEmptyListWithoutThrowing() throws IOException {
+        File bad = tempDir.resolve("confirmout.json").toFile();
+        Files.writeString(bad.toPath(), "{ this is not valid json ");
+
+        List<DeviceErrorStatus> result = DeviceErrorStatusResponse.loadDeviceErrorStatuses(bad);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void loadDeviceErrorStatuses_WhenValidJson_ReturnsADeviceStatusPerTopLevelField() throws IOException {
+        File good = tempDir.resolve("confirmout.json").toFile();
+        Files.writeString(good.toPath(), "{\"scanner\":{},\"printer\":{}}");
+
+        List<DeviceErrorStatus> result = DeviceErrorStatusResponse.loadDeviceErrorStatuses(good);
+
+        assertEquals(2, result.size());
+        assertEquals("scanner", result.get(0).deviceName);
+        assertEquals("printer", result.get(1).deviceName);
+        assertTrue(result.stream().noneMatch(status -> status.faultPresent));
+    }
+}


### PR DESCRIPTION
Relates to #16.

The original 'Could not load PropertiesLauncher' error is already resolved by the Spring Boot 3.5 upgrade (bootJar manifest and devicestarter.sh both use org.springframework.boot.loader.launch.PropertiesLauncher; verified present in the built jar).

This fixes the real remaining bug from the issue thread in DeviceErrorStatusResponse:
- Logged 'JSON is in wrong format' even when /var/tmp/CONFIRMOUT/confirmout.json was simply missing — now reports a clear 'not found' message.
- NPE when the file existed but failed to parse (IOException caught but null JsonNode dereferenced) — now returns early.
- Extracted loading into a testable method; added tests for missing/null/malformed/valid. Full suite passes.